### PR TITLE
Fix for invalid file path resolution.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ module.exports = {
                 }
             }
 
-            babelOptions.filename = path.relative(curDir, filename);
+            babelOptions.filename = filename;
             babelOptions.babelrc = false;
             let babel = getBabel();
 


### PR DESCRIPTION
I faced with problem that when I'm tried to measure coverage of tests ran by `mocha-puppeteer` with `nyc` (istanbul) it generates report where all files are placed in root. Also I was unable to open page with file coverage (it reports something like `Unable to lookup source: PlaceholderRoles.js(ENOENT: no such file or directory, open 'PlaceholderRoles.js')`).

I dug into this and found that problem comes from `lasso-babel-transform`.
`path.relative(curDir, filename)` will always return only name of file since `curDir` is just a folder where this file placed (see line 52).

I'm not 100% sure about proposed fix, but at least it fixed my problem.